### PR TITLE
Better error handling for schema creation

### DIFF
--- a/lib/ecto_mnesia/storage.ex
+++ b/lib/ecto_mnesia/storage.ex
@@ -80,7 +80,7 @@ defmodule Ecto.Mnesia.Storage do
   Checks that the Application environment for `mnesia_dir` is of
   a correct type.
   """
-  def check_mnesia_dir() do
+  def check_mnesia_dir do
     dir = Application.get_env(:mnesia, :dir, nil)
     case dir do
       nil -> Logger.error "Mnesia dir is not set. Mnesia will not work."

--- a/lib/ecto_mnesia/storage.ex
+++ b/lib/ecto_mnesia/storage.ex
@@ -38,10 +38,10 @@ defmodule Ecto.Mnesia.Storage do
   def storage_up(config) do
     config = conf(config)
 
-    IO.puts "==> Setting Mnesia schema table copy type"
+    Logger.info "==> Setting Mnesia schema table copy type"
     Mnesia.change_table_copy_type(:schema, config[:host], config[:storage_type])
 
-    IO.puts "==> Ensuring Mnesia schema exists"
+    Logger.info "==> Ensuring Mnesia schema exists"
     case Mnesia.create_schema([config[:host]]) do
       {:error, {_, {:already_exists, _}}} -> {:error, :already_up}
       :ok -> :ok

--- a/lib/ecto_mnesia/storage.ex
+++ b/lib/ecto_mnesia/storage.ex
@@ -44,6 +44,9 @@ defmodule Ecto.Mnesia.Storage do
     Logger.info "==> Ensuring Mnesia schema exists"
     case Mnesia.create_schema([config[:host]]) do
       {:error, {_, {:already_exists, _}}} -> {:error, :already_up}
+      {:error, reason} ->
+          Logger.error "create_schema failed with reason #{inspect reason}"
+          {:error, :unknown}
       :ok -> :ok
     end
   end


### PR DESCRIPTION
If you misconfigure the mensia directory than the schema creation fails but gives no clue for origin of the problem. Therefore I added a check function that reports the misconfigured (i.e. wrong typing) mnesia directory environment variable. I also changed the `IO.puts` output to proper logger via `Logger`.  