### PR TITLE
Add support for arbitrary Mnesia arguments

### DIFF
--- a/lib/ecto_mnesia/storage/migrator.ex
+++ b/lib/ecto_mnesia/storage/migrator.ex
@@ -174,7 +174,11 @@ defmodule EctoMnesia.Storage.Migrator do
         type when type in [:set, :ordered_set, :bag] ->
           [{:type, type}]
         opts when is_list(opts) ->
-          opts
+          if opts[:type] == nil do
+            [type: :ordered_set] ++ opts
+          else
+            opts
+          end
       end
     
     config = conf(repo)


### PR DESCRIPTION
This adds support for passing additional arguments to Mnesia.create_table().

The previous engine "type" parameters are checked to
maintain backwards compatibility