### PR TITLE
Updates MatchSpec to work with tuples (like datetimes) in queries.

### DIFF
--- a/lib/ecto_mnesia/record/context/match_spec.ex
+++ b/lib/ecto_mnesia/record/context/match_spec.ex
@@ -59,8 +59,7 @@ defmodule EctoMnesia.Record.Context.MatchSpec do
   defp match_conditions(%Ecto.Query{wheres: wheres}, sources, context),
     do: match_conditions(wheres, sources, context, [])
 
-  defp match_conditions([], _sources, _context, acc),
-    do: acc
+  defp match_conditions([], _sources, _context, acc), do: acc
 
   defp match_conditions([%{expr: expr, params: params} | tail], sources, context, acc) do
     condition = condition_expression(expr, merge_sources(sources, params), context)
@@ -158,6 +157,7 @@ defmodule EctoMnesia.Record.Context.MatchSpec do
     unbound_elems = :lists.map(&unbind(&1, sources), elems)
     {:erlang.list_to_tuple(unbound_elems)}
   end
+
   def unbind(value, _sources), do: value
 
   # Binded variable value

--- a/lib/ecto_mnesia/record/context/match_spec.ex
+++ b/lib/ecto_mnesia/record/context/match_spec.ex
@@ -151,6 +151,13 @@ defmodule EctoMnesia.Record.Context.MatchSpec do
     |> get_binded()
   end
 
+  # Tuples need to wrapped in extra layer of {}.
+  # (And for nested tuples this needs to happen at each level.)
+  def unbind(value, sources) when is_tuple(value) do
+    elems = :erlang.tuple_to_list(value)
+    unbound_elems = :lists.map(&unbind(&1, sources), elems)
+    {:erlang.list_to_tuple(unbound_elems)}
+  end
   def unbind(value, _sources), do: value
 
   # Binded variable value

--- a/test/unit/adapter_test.exs
+++ b/test/unit/adapter_test.exs
@@ -196,9 +196,15 @@ defmodule EctoMnesia.AdapterTest do
   describe "select" do
     setup do
       {:ok, loan1} =
-        TestRepo.insert(%SellOffer{loan_id: "hello", age: 11, loan_changes: ["old_application", "new_application"], booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:38:40])})
+        TestRepo.insert(%SellOffer{
+          loan_id: "hello",
+          age: 11,
+          loan_changes: ["old_application", "new_application"],
+          booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:38:40])
+        })
 
-      {:ok, loan2} = TestRepo.insert(%SellOffer{loan_id: "hello", age: 15, booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:48:40])})
+      {:ok, loan2} =
+        TestRepo.insert(%SellOffer{loan_id: "hello", age: 15, booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:48:40])})
 
       %{loan1: loan1, loan2: loan2}
     end

--- a/test/unit/adapter_test.exs
+++ b/test/unit/adapter_test.exs
@@ -196,9 +196,9 @@ defmodule EctoMnesia.AdapterTest do
   describe "select" do
     setup do
       {:ok, loan1} =
-        TestRepo.insert(%SellOffer{loan_id: "hello", age: 11, loan_changes: ["old_application", "new_application"]})
+        TestRepo.insert(%SellOffer{loan_id: "hello", age: 11, loan_changes: ["old_application", "new_application"], booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:38:40])})
 
-      {:ok, loan2} = TestRepo.insert(%SellOffer{loan_id: "hello", age: 15})
+      {:ok, loan2} = TestRepo.insert(%SellOffer{loan_id: "hello", age: 15, booked_at: Ecto.DateTime.cast!(~N[2018-06-12 23:48:40])})
 
       %{loan1: loan1, loan2: loan2}
     end
@@ -225,6 +225,12 @@ defmodule EctoMnesia.AdapterTest do
       assert_raise RuntimeError, "Complex :in queries is not supported by the Mnesia adapter.", fn ->
         TestRepo.all(from(so in SellOffer, where: ^change in so.loan_changes))
       end
+    end
+
+    test "where with datetime (tests tuple support of MatchSpec)" do
+      datetime = ~N[2018-06-12 23:00:00]
+      res = TestRepo.all(from(so in SellOffer, where: so.inserted_at >= ^datetime))
+      assert length(res) == 2
     end
 
     test "structured" do


### PR DESCRIPTION
Resolves #63 by wrapping tuples during conversion to match_spec into an extra set of `{}`.