### PR TITLE
#67 Mnesia Cyclic error - Don't catch the exit message

### DIFF
--- a/lib/ecto_mnesia/table.ex
+++ b/lib/ecto_mnesia/table.ex
@@ -195,8 +195,6 @@ defmodule EctoMnesia.Table do
     :exit, {:aborted, {:no_exists, [schema, _id]}} -> {:raise, "Schema #{inspect(schema)} does not exist"}
     :exit, {:aborted, {:no_exists, schema}} -> {:raise, "Schema #{inspect(schema)} does not exist"}
     :exit, {:aborted, :rollback} -> {:error, :rollback}
-    :exit, {:aborted, reason} -> {:error, reason, System.stacktrace()}
-    :exit, reason -> {:error, reason, System.stacktrace()}
   end
 
   defp do_activity(context, fun) do


### PR DESCRIPTION
Check this issue - https://github.com/Nebo15/ecto_mnesia/issues/67
Solution -We should not do catch Mnesia.Transaction. Referring - StackOverflow (https://stackoverflow.com/a/8105191/2000121).