### PR TITLE
Fix Elixir/dialyzer warnings

### DIFF
--- a/lib/ecto_mnesia/record/context/match_spec.ex
+++ b/lib/ecto_mnesia/record/context/match_spec.ex
@@ -29,9 +29,9 @@ defmodule EctoMnesia.Record.Context.MatchSpec do
 
   # Build match_spec head part (data placeholders)
   defp match_head(%Context{table: %Context.Table{name: table_name}} = context) do
-    context
-    |> Context.get_fields_placeholders()
-    |> Enum.into([table_name])
+    [ table_name
+    | Context.get_fields_placeholders(context)
+    ]
     |> List.to_tuple()
   end
 

--- a/lib/ecto_mnesia/storage/migrator.ex
+++ b/lib/ecto_mnesia/storage/migrator.ex
@@ -123,7 +123,7 @@ defmodule EctoMnesia.Storage.Migrator do
     |> Enum.map(fn index ->
       case Mnesia.add_table_index(table, index) do
         {:atomic, :ok} -> :ok
-        {:node_not_running, not_found_node} -> raise "Node #{inspect(not_found_node)} is not started"
+        {:aborted, {:node_not_running, not_found_node}} -> raise "Node #{inspect(not_found_node)} is not started"
         {:aborted, {:already_exists, ^table, _}} -> raise "Index for field #{index} in table #{table} already exists"
       end
     end)
@@ -135,7 +135,7 @@ defmodule EctoMnesia.Storage.Migrator do
     |> Enum.map(fn index ->
       case Mnesia.add_table_index(table, index) do
         {:atomic, :ok} -> :ok
-        {:node_not_running, not_found_node} -> raise "Node #{inspect(not_found_node)} is not started"
+        {:aborted, {:node_not_running, not_found_node}} -> raise "Node #{inspect(not_found_node)} is not started"
         {:aborted, {:already_exists, ^table, _}} -> :ok
       end
     end)
@@ -147,7 +147,7 @@ defmodule EctoMnesia.Storage.Migrator do
     |> Enum.map(fn index ->
       case Mnesia.del_table_index(table, index) do
         {:atomic, :ok} -> :ok
-        {:node_not_running, not_found_node} -> raise "Node #{inspect(not_found_node)} is not started"
+        {:aborted, {:node_not_running, not_found_node}} -> raise "Node #{inspect(not_found_node)} is not started"
         {:aborted, {:no_exists, ^table, _}} -> raise "Index for field #{index} in table #{table} does not exists"
       end
     end)
@@ -159,7 +159,7 @@ defmodule EctoMnesia.Storage.Migrator do
     |> Enum.map(fn index ->
       case Mnesia.del_table_index(table, index) do
         {:atomic, :ok} -> :ok
-        {:node_not_running, not_found_node} -> raise "Node #{inspect(not_found_node)} is not started"
+        {:aborted, {:node_not_running, not_found_node}} -> raise "Node #{inspect(not_found_node)} is not started"
         {:aborted, {:no_exists, ^table, _}} -> :ok
       end
     end)
@@ -198,7 +198,9 @@ defmodule EctoMnesia.Storage.Migrator do
 
     case Enum.find_index(fields, &(&1 == old_field)) do
       nil ->
-        if on_not_found == :raise, do: raise("Field #{old_field} not found", else: fields)
+        if on_not_found == :raise,
+          do: raise("Field #{old_field} not found"),
+          else: fields
 
       index when is_number(index) ->
         List.replace_at(fields, index, new_field)

--- a/lib/ecto_mnesia/table.ex
+++ b/lib/ecto_mnesia/table.ex
@@ -23,7 +23,7 @@ defmodule EctoMnesia.Table do
   defp _insert(table, record) do
     case Mnesia.write(table, record, :write) do
       :ok -> {:ok, record}
-      error -> {:error, error}
+      {:aborted, reason} -> {:error, reason}
     end
   end
 


### PR DESCRIPTION
* Fix "Collectable deprecated for non-empty lists" warnings
* Fix erroneous `node_not_running` matches in `Migrator`
* Fix typo in `Migrator.reduce_fields/4` `if` statement
* Remove erroneous `error` match in `Table._insert/2`